### PR TITLE
Fixes the usage of http.path tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ services:
       - "@zipkin.default_tracing"
       - "@logger"
     tags:
-      - { name: kernel.event_listener, event: kernel.request }
+      - { name: kernel.event_listener, event: kernel.request, priority: 256 }
       - { name: kernel.event_listener, event: kernel.terminate }
       - { name: kernel.event_listener, event: kernel.exception }
 ```
@@ -136,7 +136,7 @@ services:
       - "@my_own_tracer"
       - "@logger"
     tags:
-      - { name: kernel.event_listener, event: kernel.request }
+      - { name: kernel.event_listener, event: kernel.request, priority: 256 }
       - { name: kernel.event_listener, event: kernel.terminate }
       - { name: kernel.event_listener, event: kernel.exception }
 ```

--- a/src/ZipkinBundle/Middleware.php
+++ b/src/ZipkinBundle/Middleware.php
@@ -62,8 +62,9 @@ final class Middleware
         $span->start();
         $span->setName($request->getMethod());
         $span->setKind(Kind\SERVER);
+        $span->tag(Tags\HTTP_HOST, $request->getHost());
         $span->tag(Tags\HTTP_METHOD, $request->getMethod());
-        $span->tag(Tags\HTTP_PATH, $request->getRequestUri());
+        $span->tag(Tags\HTTP_PATH, $request->getPathInfo());
 
         $this->scopeCloser = $this->tracing->getTracer()->openScope($span);
     }
@@ -90,7 +91,7 @@ final class Middleware
         if ($span !== null) {
             $span->tag(Tags\HTTP_STATUS_CODE, $event->getResponse()->getStatusCode());
             $span->finish();
-            ($this->scopeCloser)();
+            call_user_func($this->scopeCloser);
         }
 
         $this->flushTracer();

--- a/tests/Unit/MiddlewareTest.php
+++ b/tests/Unit/MiddlewareTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace ZipkinBundle\Tests\Unit;
+
+use PHPUnit_Framework_TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Zipkin\Span;
+use Zipkin\TracingBuilder;
+use ZipkinBundle\Middleware;
+
+class MiddlewareTest extends PHPUnit_Framework_TestCase
+{
+    public function testSpanIsNotCreatedOnNonMasterRequest()
+    {
+        $tracing = TracingBuilder::create()->build();
+        $logger = new NullLogger();
+
+        $middleware = new Middleware($tracing, $logger);
+
+        $event = $this->prophesize(GetResponseEvent::class);
+        $event->isMasterRequest()->willReturn(false);
+
+        $middleware->onKernelRequest($event->reveal());
+
+        $this->assertNull($tracing->getTracer()->getCurrentSpan());
+    }
+
+    public function testSpanIsCreated()
+    {
+        $tracing = TracingBuilder::create()->build();
+        $logger = new NullLogger();
+
+        $middleware = new Middleware($tracing, $logger);
+
+        $event = $this->prophesize(GetResponseEvent::class);
+        $event->isMasterRequest()->willReturn(true);
+        $event->getRequest()->willReturn(new Request());
+
+        $middleware->onKernelRequest($event->reveal());
+
+        $this->assertInstanceOf(Span::class, $tracing->getTracer()->getCurrentSpan());
+    }
+}


### PR DESCRIPTION
This PR fixes the recording of the `http.path` tag by removing the query string parameters.