### PR TITLE
Bumps to Zipkin 1.2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "symfony/http-kernel": "~2.7|~3.0",
         "symfony/routing": "~2.7|~3.0",
         "symfony/dependency-injection": "~2.7|~3.0",
-        "jcchavezs/zipkin": "~1.0.1"
+        "jcchavezs/zipkin": "~1.2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,35 @@
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.5/phpunit.xsd"
+        backupGlobals="true"
+        backupStaticAttributes="false"
+        bootstrap="./vendor/autoload.php"
+        cacheTokens="false"
+        colors="false"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        forceCoversAnnotation="false"
+        mapTestClassNameToCoveredClassName="false"
+        printerClass="PHPUnit_TextUI_ResultPrinter"
+        processIsolation="false"
+        stopOnError="false"
+        stopOnFailure="false"
+        stopOnIncomplete="false"
+        stopOnSkipped="false"
+        stopOnRisky="false"
+        testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
+        timeoutForSmallTests="1"
+        timeoutForMediumTests="10"
+        timeoutForLargeTests="60"
+        verbose="false">
+		<filter>
+			<whitelist processUncoveredFilesFromWhitelist="true">
+				<directory suffix=".php">./src</directory>
+				<exclude>
+					<directory>./vendor</directory>
+					<directory>./tests</directory>
+				</exclude>
+			</whitelist>
+		</filter>
+</phpunit>

--- a/src/ZipkinBundle/DependencyInjection/Configuration.php
+++ b/src/ZipkinBundle/DependencyInjection/Configuration.php
@@ -49,6 +49,7 @@ final class Configuration implements ConfigurationInterface
                 ->arrayNode('reporter')->addDefaultsIfNotSet()
                     ->children()
                         ->scalarNode('type')->defaultValue('log')->end()
+                        ->scalarNode('metrics')->defaultValue(null)->end()
                         ->arrayNode('http')->addDefaultsIfNotSet()
                             ->children()
                                 ->scalarNode('endpoint_url')->defaultValue('http://zipkin:9411/api/v2/spans')->end()

--- a/src/ZipkinBundle/DependencyInjection/ZipkinExtension.php
+++ b/src/ZipkinBundle/DependencyInjection/ZipkinExtension.php
@@ -63,6 +63,11 @@ final class ZipkinExtension extends Extension
         );
 
         $container->setParameter(
+            'zipkin.reporter.metrics',
+            $config['reporter']['metrics']
+        );
+
+        $container->setParameter(
             'zipkin.reporter.http',
             $config['reporter']['http']
         );

--- a/src/ZipkinBundle/TracingFactory.php
+++ b/src/ZipkinBundle/TracingFactory.php
@@ -49,6 +49,7 @@ final class TracingFactory
     private static function buildReporter(ContainerInterface $container)
     {
         $reporterName = $container->getParameter('zipkin.reporter.type');
+        $metricsName = $container->getParameter('zipkin.reporter.metrics');
 
         switch ($reporterName) {
             default:
@@ -59,7 +60,11 @@ final class TracingFactory
                 return new Noop();
                 break;
             case 'http':
-                return new Http(null, $container->getParameter('zipkin.reporter.http'));
+                return new Http(
+                    null,
+                    $container->getParameter('zipkin.reporter.http'),
+                    $metricsName === null ? null : $container->get($metricsName)
+                );
         }
     }
 

--- a/tests/Unit/MiddlewareTest.php
+++ b/tests/Unit/MiddlewareTest.php
@@ -61,6 +61,7 @@ class MiddlewareTest extends PHPUnit_Framework_TestCase
         $middleware->onKernelRequest($event->reveal());
 
         $exceptionEvent = $this->prophesize(GetResponseForExceptionEvent::class);
+        $exceptionEvent->isMasterRequest()->willReturn(false);
         $exceptionEvent->getException()->shouldNotBeCalled();
         $middleware->onKernelException($exceptionEvent->reveal());
     }
@@ -79,6 +80,7 @@ class MiddlewareTest extends PHPUnit_Framework_TestCase
         $middleware->onKernelRequest($event->reveal());
 
         $exceptionEvent = $this->prophesize(GetResponseForExceptionEvent::class);
+        $exceptionEvent->isMasterRequest()->willReturn(true);
         $exceptionEvent->getException()->shouldBeCalled()->willReturn(new Exception());
         $middleware->onKernelException($exceptionEvent->reveal());
     }
@@ -97,6 +99,7 @@ class MiddlewareTest extends PHPUnit_Framework_TestCase
         $middleware->onKernelRequest($event->reveal());
 
         $responseEvent = $this->prophesize(PostResponseEvent::class);
+        $responseEvent->isMasterRequest()->willReturn(false);
         $responseEvent->getRequest()->shouldNotBeCalled();
         $middleware->onKernelTerminate($responseEvent->reveal());
     }
@@ -116,6 +119,7 @@ class MiddlewareTest extends PHPUnit_Framework_TestCase
         $middleware->onKernelRequest($event->reveal());
 
         $exceptionEvent = $this->prophesize(PostResponseEvent::class);
+        $exceptionEvent->isMasterRequest()->willReturn(true);
         $exceptionEvent->getRequest()->shouldBeCalled()->willReturn($request);
         $exceptionEvent->getResponse()->shouldBeCalled()->willReturn(new Response);
         $middleware->onKernelTerminate($exceptionEvent->reveal());

--- a/tests/Unit/TracingFactoryTest.php
+++ b/tests/Unit/TracingFactoryTest.php
@@ -15,7 +15,8 @@ final class TracingFactoryTest extends PHPUnit_Framework_TestCase
         'zipkin.noop' => false,
         'zipkin.service_name' => 'symfony',
         'zipkin.sampler.type' => 'always',
-        'zipkin.reporter.type' => 'log'
+        'zipkin.reporter.type' => 'log',
+        'zipkin.reporter.metrics' => null
     ];
 
     /**


### PR DESCRIPTION
This bumps to Zipkin 1.2.1 and also fixes a bug while setting the name of the span, from the `onKernelRequest` (route is not resolved yet here) to `onKernelTerminate`.

Version `1.1.0` should come from this.

Ping @ptlis 

Closes #14 
